### PR TITLE
Add “short track roulette”

### DIFF
--- a/nkdsu/apps/vote/context_processors.py
+++ b/nkdsu/apps/vote/context_processors.py
@@ -27,7 +27,7 @@ def get_sections(request):
         ('home', reverse('vote:index')),
         ('archive', reverse('vote:archive')),
         ('new tracks', most_recent_track.show_revealed().get_revealed_url()),
-        ('roulette', reverse('vote:roulette', kwargs={'mode': 'hipster'})),
+        ('roulette', reverse('vote:roulette')),
         ('stats', reverse('vote:stats')),
         ('donate', 'https://www.patreon.com/NekoDesu'),
         ('etc', 'http://nekodesu.co.uk/'),

--- a/nkdsu/apps/vote/urls.py
+++ b/nkdsu/apps/vote/urls.py
@@ -111,7 +111,10 @@ urlpatterns = [
     url(r'^added/(?P<date>[\d-]+)/$', views.Added.as_view(), name='added'),
     url(r'^added/$', views.Added.as_view(), name='added'),
 
-    url(r'^roulette/(?P<mode>indiscriminate|hipster|almost-100|pro)/$',
+    url(r'^roulette/'
+        r'(?P<mode>indiscriminate|hipster|almost-100|pro|short-tracks)/$',
+        views.Roulette.as_view(), name='roulette'),
+    url(r'^roulette/(?P<mode>short-tracks)/(?P<minutes>[0-9]+)/?$',
         views.Roulette.as_view(), name='roulette'),
     url(r'^roulette/$', views.Roulette.as_view(), name='roulette'),
 

--- a/nkdsu/settings.py
+++ b/nkdsu/settings.py
@@ -17,6 +17,8 @@ from dateutil.relativedelta import SA, relativedelta
 PROJECT_DIR = os.path.realpath(os.path.join(__file__, '..'))
 PROJECT_ROOT = os.path.realpath(os.path.join(PROJECT_DIR, '..'))
 
+ALLOWED_HOSTS = ['127.0.0.1', 'localhost']
+
 CELERY_TIMEZONE = 'Europe/London'
 
 BROKER_URL = "amqp://guest:guest@127.0.0.1:5672//"
@@ -70,8 +72,8 @@ MIXCLOUD_FEED_URL = 'http://api.mixcloud.com/NekoDesu/feed/'
 LASTFM_API_KEY = ''  # secret
 LASTFM_API_SECRET = ''  # secret
 
-DEBUG = False
-TEMPLATE_DEBUG = DEBUG
+DEBUG = True
+TEMPLATE_DEBUG = True
 
 TEMPLATES = [
     {

--- a/nkdsu/settings.py
+++ b/nkdsu/settings.py
@@ -17,8 +17,6 @@ from dateutil.relativedelta import SA, relativedelta
 PROJECT_DIR = os.path.realpath(os.path.join(__file__, '..'))
 PROJECT_ROOT = os.path.realpath(os.path.join(PROJECT_DIR, '..'))
 
-ALLOWED_HOSTS = ['127.0.0.1', 'localhost']
-
 CELERY_TIMEZONE = 'Europe/London'
 
 BROKER_URL = "amqp://guest:guest@127.0.0.1:5672//"
@@ -72,8 +70,8 @@ MIXCLOUD_FEED_URL = 'http://api.mixcloud.com/NekoDesu/feed/'
 LASTFM_API_KEY = ''  # secret
 LASTFM_API_SECRET = ''  # secret
 
-DEBUG = True
-TEMPLATE_DEBUG = True
+DEBUG = False
+TEMPLATE_DEBUG = DEBUG
 
 TEMPLATES = [
     {

--- a/nkdsu/templates/roulette.html
+++ b/nkdsu/templates/roulette.html
@@ -6,14 +6,29 @@
 
   <h2>roulette</h2>
   <p class="subheading roulette-mode-switch selected-{{ mode }}">
-    {% for slug, name in modes %}
-      <span class="roulette-{{ slug }}">
-        {% if mode == slug %}
-          {{ name }}
-        {% else %}
-          <a href="{% url "vote:roulette" mode=slug %}">{{ name }}</a>
-        {% endif %}
-      </span>
+    {% for slug, name, public in modes %}
+      {% if public or user.is_staff %}
+        <span class="roulette-{{ slug }}">
+          {% if mode == slug %}
+            {{ name }}
+          {% else %}
+            <a href="{% url "vote:roulette" mode=slug %}">{{ name }}</a>
+          {% endif %}
+          {% if mode == slug and mode == 'short-tracks' %}
+          (
+            {% for minute_slug in allowed_minutes %}
+              <span class="roulette-{{ minute_slug }}">
+                {% if minutes == minute_slug %}
+                  {{ minutes }}
+                {% else %}
+                  <a href="{% url "vote:roulette" mode="short-tracks" minutes=minute_slug %}">{{ minute_slug }}</a>
+                {% endif %}
+              </span>
+            {% endfor %}
+          mins. )
+          {% endif %}
+        </span>
+      {% endif %}
     {% endfor %}
   </p>
 

--- a/nkdsu/tests.py
+++ b/nkdsu/tests.py
@@ -53,7 +53,7 @@ class EverythingTest(
         '/roulette/indiscriminate/',
         '/roulette/hipster/',
         '/roulette/pro/',
-        '/roulette/minute/1',
+        '/roulette/short-tracks/1',
         '/archive/',
         '/stats/',
         '/0007C3F2760E0541/',

--- a/nkdsu/tests.py
+++ b/nkdsu/tests.py
@@ -53,6 +53,7 @@ class EverythingTest(
         '/roulette/indiscriminate/',
         '/roulette/hipster/',
         '/roulette/pro/',
+        '/roulette/minute/1',
         '/archive/',
         '/stats/',
         '/0007C3F2760E0541/',


### PR DESCRIPTION
(This PR should only be merged if @theshillito agrees it’s useful)

This change adds a new roulette mode, only presented to staff users, which lists tracks shorter than N minutes (but longer than N – 1 minutes). The staff user can choose between 1, 2, and 3 minutes (but other lengths can in practice be used by manually tweaking the URL)

To facilitate this, the concept of roulettes being “public” is introduced; non-public roulettes are not presented in the UI, although are not currently access controlled—a user who knows the URL can use them. This could be changed if desired. 

The layout of the length selector is added relatively by hand to `roulette.html`, similarly to how the text change for pro roulette is implemented.