### PR TITLE
change 'by' to 'featuring' on artist pages

### DIFF
--- a/nkdsu/templates/artist_detail.html
+++ b/nkdsu/templates/artist_detail.html
@@ -14,12 +14,14 @@
   <p class="subheading">
     {% if tracks|length == 0 %}
       This isn't currently an artist that we recognise in the library.
+
       {% if artist_suggestions %}
         You might be looking for:
         {% for suggestion in artist_suggestions %}
           <a href="{% url "vote:artist" artist=suggestion %}">{{ suggestion }}</a>{% if forloop.last %}. {% else %}, {% endif %}
         {% endfor %}
       {% endif %}
+
       You may want to <a href="{% url "vote:search" %}?q={{ artist|urlencode }}">run a search</a> if that's unhelpful.
 
     {% elif tracks|length == 1 %}
@@ -44,7 +46,7 @@
       {% endif %}
 
     {% else %}
-      {{ played|length }} of these {{ tracks|length }} tracks have been played.
+      {{ played|length }} of these {{ tracks|length }} tracks {{ played|length|pluralize:"has,have" }} been played.
     {% endif %}
   </p>
 

--- a/nkdsu/templates/artist_detail.html
+++ b/nkdsu/templates/artist_detail.html
@@ -24,16 +24,27 @@
 
     {% elif tracks|length == 1 %}
       {% if played|length == 0 %}
-        The only track in the library featuring {{ artist }} has not yet been played.
+        The only track here has not yet been played.
       {% else %}
         All of these tracks have been played, but there's only one of them, so take that as you will.
       {% endif %}
+
     {% elif played|length == tracks|length %}
-      All {{ tracks|length }} tracks featuring {{ artist }} in the library have been played.
+      {% if tracks|length == 2 %}
+        Both of these tracks have been played.
+      {% else %}
+        All {{ tracks|length }} of these tracks have been played.
+      {% endif %}
+
     {% elif played|length == 0 %}
-      None of the {{ tracks|length }} track{{ tracks|pluralize }} featuring {{ artist }} have been played.
+      {% if tracks|length == 2 %}
+        Neither of the tracks here have been played.
+      {% else %}
+        None of the {{ tracks|length }} tracks here have been played.
+      {% endif %}
+
     {% else %}
-      {{ played|length }} of the {{ tracks|length }} track{{ tracks|pluralize }} featuring {{ artist }} in the library {{ played|pluralize:"has,have" }} been played.
+      {{ played|length }} of these {{ tracks|length }} tracks have been played.
     {% endif %}
   </p>
 

--- a/nkdsu/templates/artist_detail.html
+++ b/nkdsu/templates/artist_detail.html
@@ -24,16 +24,16 @@
 
     {% elif tracks|length == 1 %}
       {% if played|length == 0 %}
-        The only track in the library by {{ artist }} has not yet been played.
+        The only track in the library featuring {{ artist }} has not yet been played.
       {% else %}
         All of these tracks have been played, but there's only one of them, so take that as you will.
       {% endif %}
     {% elif played|length == tracks|length %}
-      All {{ tracks|length }} tracks by {{ artist }} in the library have been played.
+      All {{ tracks|length }} tracks featuring {{ artist }} in the library have been played.
     {% elif played|length == 0 %}
-      None of the {{ tracks|length }} track{{ tracks|pluralize }} by {{ artist }} have been played.
+      None of the {{ tracks|length }} track{{ tracks|pluralize }} featuring {{ artist }} have been played.
     {% else %}
-      {{ played|length }} of the {{ tracks|length }} track{{ tracks|pluralize }} by {{ artist }} in the library {{ played|pluralize:"has,have" }} been played.
+      {{ played|length }} of the {{ tracks|length }} track{{ tracks|pluralize }} featuring {{ artist }} in the library {{ played|pluralize:"has,have" }} been played.
     {% endif %}
   </p>
 


### PR DESCRIPTION
There are many songs where an artist is featured on it (and in the artist tag), but not necessarily the main song artist. I think changing to featuring makes this more accurate.