### PR TITLE
add pre-commit hooks using pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,38 @@
+default_language_version:
+    python: python3.11
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+-   repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+    -   id: black
+-   repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+    -   id: flake8
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.991
+    hooks:
+    -   id: mypy
+        args: [--pretty, --show-error-context]
+        language: system
+-   repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v8.33.0
+    hooks:
+    -   id: eslint
+        additional_dependencies:
+        -   eslint@7.32.0
+        -   eslint-config-standard@16.0.3
+        -   eslint-plugin-import@2.25.2
+        -   eslint-plugin-node@11.1.0
+        -   eslint-plugin-promise@5.1.0
+        -   less@4.1.2
+        -   uglify-js@3.14.2
+        -   yuglify@2.0.0
+        files: nkdsu/static/js/

--- a/API.md
+++ b/API.md
@@ -14,7 +14,7 @@ Includes:
 - `playlist`: a list of tracks played and the times at which they were played
 - `added`: a list of all the tracks added to the library this week
 - `start`: the date and time at which this week started
-- `finish`: the date and time at which this week ended 
+- `finish`: the date and time at which this week ended
 - `showtime`: the date and time at which this week's show began
 - `broadcasting`: if this show is on the air at the time of the request
 - `message_markdown` and `message_html`: the message shown on the front page

--- a/nkdsu/apps/vote/fixtures/vote.json
+++ b/nkdsu/apps/vote/fixtures/vote.json
@@ -333,7 +333,7 @@
   "fields": {
     "track": "001D8E8B3A5DDDB9",
     "index": 0,
-    "show": 79 
+    "show": 79
   }
 },
 {

--- a/nkdsu/static/less/_browse.less
+++ b/nkdsu/static/less/_browse.less
@@ -122,7 +122,7 @@ ul.browsable-categories {
       font-weight: bold;
       overflow: hidden;
       border-radius: .2em;
-      
+
       span {
         display: inline-block;
         position: relative;

--- a/nkdsu/static/less/_standalone_vote.less
+++ b/nkdsu/static/less/_standalone_vote.less
@@ -10,7 +10,7 @@
   @media (min-width: @breakpoint) {
     width: 50%;
   }
-  
+
   .tracks {
     clear: both;
 

--- a/nkdsu/static/less/_track.less
+++ b/nkdsu/static/less/_track.less
@@ -1,4 +1,4 @@
-@import "_mixins.less"; 
+@import "_mixins.less";
 
 @metadata-width: 60%;
 @new-compensation: 2.7em;

--- a/nkdsu/templates/include/track.html
+++ b/nkdsu/templates/include/track.html
@@ -17,7 +17,7 @@
       new
     {% endif %}
     {% if track.inudesu %}
-      inudesu 
+      inudesu
     {% endif %}
     {% if tiny %}
       tiny

--- a/nkdsu/templates/index.html
+++ b/nkdsu/templates/index.html
@@ -1,6 +1,6 @@
 {% extends parent %}
 {% load vote_tags %}
-  
+
 {% block content %}
 
   {% include "include/show_message.html" %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ flake8>=3.8
 musicbrainzngs==0.5
 mypy>=0.990,<1
 ndg-httpsclient
+pre-commit>=3.0.2
 psycopg2
 pyasn1
 pytest>=7.1<8


### PR DESCRIPTION
This addresses the suggestion in #237.

It uses [pre-commit](https://www.pre-commit.com) to automatically run the four sets of stylistic checks currently run in CI:

* `black`
* `mypy`
* `flake8`
* `eslint`

It also does a couple of extra checks that are in the default pre-commit config:

* Check for trailing whitespace on lines
* Check for blank lines at end of file
* Check that YAML syntax is valid
* Check that no large files have been added accidentally

It doesn't run the test suite, as the consensus seems to be that that takes too long to be a good commit hook, slowing down the development process. (This also avoids the issue of avoiding needing to squash whatever database was being developed against in favour of having the test database loaded, although I doubt this would be insurmountable.)

pre-commit automatically creates isolated environments in which to run all tests apart from `mypy`, which requires an active virtual environment with all requirements installed. (The alternative is maintaining a parallel copy of `requirements.txt` inside `.pre-commit-config.yaml`, which seems to introduce too high a maintenance burden. This is apparently due to problems with cache invalidation when reading requirements from any file other than `.pre-commit-config.yaml`.)

Also included are changes to a few files that had trailing whitespace that `pre-commit` picked up on first run. `flake8` also complains about line length in some migrations, but I have not acted on this.

Two possible further improvements:

* Currently there is redundancy between the specification of rules in `.pre-commit-config.yaml` and in the combination of `package.json` and `.github/workflows/test.yml`. (In particular, the dependencies for `eslint` are specified twice.) This could be in principle rationalised, so that GitHub Actions uses pre-commit rather than having its own separate specification, and developers run `pre-commit run` rather than the current `npm run-script`.
* There could be a guide (`CONTRIBUTING.md`?) walking new contributors through setting up pre-commit (and any other setup steps, although most others are already covered in `PANIC.md`.