### PR TITLE
Precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "check-migrations": "python manage.py makemigrations --dry-run --check",
     "lint-black": "black --check --diff .",
     "lint-flake8": "flake8 .",
-    "lint-js": "eslint nkdsu/static/js",
+    "lint-js": "npm exec eslint nkdsu/static/js",
     "lint-mypy": "mypy --pretty --show-error-context",
     "manage": "python manage.py",
     "test": "pytest"

--- a/precommit_hooks/README.md
+++ b/precommit_hooks/README.md
@@ -1,0 +1,10 @@
+# Pre-commit hooks for nkd.su
+
+Pre-commit hooks will check the following have not been added:
+
+ * Superfluous whitespace at end of line or end of file
+ * Missing line end at end of file
+ * JavaScript code style errors as judged using eslint
+ * Python code style errors as judged using black
+
+To enable this, copy `pre-commit` into `.git/hooks/`.

--- a/precommit_hooks/main.sh
+++ b/precommit_hooks/main.sh
@@ -91,8 +91,13 @@ then
 
     # We need to look just at our staging area
     # Temporarily complete this commit so git can clean up the rest
-    git commit --no-verify -m "temporary commit" > "${detailed_log}"
-    git clean -- ':!node_modules' > "${detailed_log}"
+    git commit --no-verify -m "temporary commit" >> "${detailed_log}"
+
+    # Purge any changes to tracked files not in the commit
+    git checkout HEAD -- .
+
+    # Remove any untracked files (but keep node modules)
+    git clean -- ':!node_modules' >> "${detailed_log}"
 
     cleanup() {
 	rm -r "${temp_dir}"

--- a/precommit_hooks/main.sh
+++ b/precommit_hooks/main.sh
@@ -57,12 +57,14 @@ fi
 
 if [[ ${python_modified} || ${js_modified} || ${yaml_modified} || ${rst_modified} ]]
 then
+    cd "${root_dir}"
+
     # We need to look just at our staging area
     # Temporarily complete this commit so we can stash the rest
     git commit --no-verify -m "temporary commit" > "${detailed_log}"
 
     # Stash everything else
-    git stash push --all > "${detailed_log}"
+    git stash push --all -- ':!node_modules' > "${detailed_log}"
 
     dirty=1
 
@@ -92,8 +94,6 @@ then
     }
 
     trap 'cleanup_and_exit' SIGINT
-
-    cd "${root_dir}"
 
     if [ ${python_modified} ]
     then

--- a/precommit_hooks/main.sh
+++ b/precommit_hooks/main.sh
@@ -34,21 +34,21 @@ then
 fi
 
 
-if git diff-index --cached ${against} -- | grep '\.py$' > "${detailed_log}"
+if git diff-index --cached ${against} -- | grep '\.py$' >> "${detailed_log}"
 then
     python_modified=1
 else
     python_modified=
 fi
 
-if git diff-index --cached ${against} -- | grep '\.js$' > "${detailed_log}"
+if git diff-index --cached ${against} -- | grep '\.js$' >> "${detailed_log}"
 then
     js_modified=1
 else
     js_modified=
 fi
 
-if git diff-index --cached ${against} -- | grep '\.rst$' > "${detailed_log}"
+if git diff-index --cached ${against} -- | grep '\.rst$' >> "${detailed_log}"
 then
     rst_modified=1
 else
@@ -73,6 +73,8 @@ then
 	echo "Unable to create temporary directory, skipping checks that need a clean repo."
 	exit_with_status
     fi
+
+    echo "Temporary directory created at ${temp_dir}" >> "${detailed_log}"
 
     # Copy everything and then clean up later
     # More efficient would be to only copy what we need, but that's a harder problem to solve

--- a/precommit_hooks/main.sh
+++ b/precommit_hooks/main.sh
@@ -83,11 +83,15 @@ then
 
 	cd "${original_wd}"
 	dirty=
+    }
+
+    cleanup_and_exit() {
+	cleanup
 
 	exit 1
     }
 
-    trap 'cleanup' SIGINT
+    trap 'cleanup_and_exit' SIGINT
 
     cd "${root_dir}"
 

--- a/precommit_hooks/main.sh
+++ b/precommit_hooks/main.sh
@@ -67,7 +67,7 @@ exit_with_status() {
 
 if [[ ${python_modified} || ${js_modified} || ${yaml_modified} || ${rst_modified} ]]
 then
-    temp_dir=$(mktemp -d)
+    temp_dir="$(mktemp -d)"
     if [ "$?" != 0 ]
     then
 	echo "Unable to create temporary directory, skipping checks that need a clean repo."
@@ -78,15 +78,16 @@ then
 
     # Copy everything and then clean up later
     # More efficient would be to only copy what we need, but that's a harder problem to solve
-    cp -r ${root_dir} ${temp_dir}/
+    cp -R "${root_dir}" "${temp_dir}/"
     if [ "$?" != 0 ]
     then
 	echo "Unable to copy repository into temporary directory, skipping checks that need a clean repo."
-	rm -r ${temp_dir}
+	echo
+	rm -rf "${temp_dir}"
 	exit_with_status
     fi
 
-    cd ${temp_dir}/$(basename ${root_dir})
+    cd "${temp_dir}/$(basename ${root_dir})"
 
     # We need to look just at our staging area
     # Temporarily complete this commit so git can clean up the rest
@@ -94,7 +95,7 @@ then
     git clean -- ':!node_modules' > "${detailed_log}"
 
     cleanup() {
-	rm -r ${temp_dir}
+	rm -r "${temp_dir}"
     }
 
     cleanup_and_exit() {

--- a/precommit_hooks/pre-commit
+++ b/precommit_hooks/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+root_dir=$(git rev-parse --show-toplevel)
+exec bash ${root_dir}/precommit_hooks/main.sh


### PR DESCRIPTION
This supersedes #240 and addresses #237

Based on discussions on Slack I suspect this may not be mergeable, but wanted to discuss anyway.

My priorities when implementing this were roughly prioritised as:
 - The hook should never block a commit that would pass all of the checks in isolation (no false positives—it shouldn't matter if the working directory is dirty, or because the hook implementation doesn't function correctly)
 - The hook should prevent commits that do not pass any of the checks that can run in a single-digit number of seconds. There should be no need for `placate flake8` commits. (`git commit --no-verify` is right there if it is needed, but my strong opinion is that hooks need to introduce friction to be meaningful, otherwise they are like compiler and deprecation warnings and will be ignored until they do cause friction)
 - Per discussion in #240, avoid using `.pre-commit-config.yaml`
 - Per discussion on Slack, do not temporarily or otherwise destroy anything in the working directory.
 - Do not change anything in the commit (that should be a smudge/clean filter instead) or in the working directory (this is a difference from the `.pre-commit-config.yaml` way of doing things, because I usually get confused when I try to commit and it rewrites my stuff)

Things it checks: 
 - Superfluous whitespace at EOL and EOF (by using `git diff-index`'s built-in functionality)
 - Missing newlines at EOF (by doing some horrible parsing of `git diff-index output`)
 - `black`
 - `flake8`
 - `mypy`
 - Django `check-migrations`
 - building the documentation with `make html`
 - `eslint`

All of these apart from the first two require creating a copy of the repo in a temporary directory to be able to remove any files that the linters shouldn't check without affecting any open file handles in the working directory. (This also helps avoid polluting the reflog.) If creating that fails, these tests are skipped. The directory is removed before the hook finishes, including if it is aborted with Ctrl+C.

This requires a non-zero amount of machinery, but significantly less than used by `.pre-commit-config.yaml`, and is what I would consider the minimal required to satisfactorily run linters in a pre-commit hook (in a way I would be willing to use in my workflow).